### PR TITLE
Added option to show your panel position in unfinished games list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Play:
 - Play modes for those who only caption or only draw
 - Enter pressed in caption mode submits the caption
 - Ability to bookmark games without participating
+- Show your panel position in unfinished games list
 
 Forum:
 
@@ -90,6 +91,9 @@ Forum:
 - add simple layers(?)
 
 ## CHANGELOG
+
+0.60.2014.9
+- Show your panel position in unfinished games list
 
 0.59.2014.8
 - Add an option to proxy imgur links (hello censorship)


### PR DESCRIPTION
I want to track how my games are progressing, but it is hard to remember which panel number I got.

I have added this functionality into your script (disabled by default). When enabled, panel position is saved upon submit and then shown on profile page.
![profile page preview](https://monosnap.com/image/CWrpUAmnOmCXwLlrYFKLhAesMzCXgc.png)

A known problem is that it will remember a position incorrectly for games created before the function is enabled when you visit them. I'm too lazy to fix it now.
