### PR TITLE
Automatically retry failed AJAX requests to reduce annoying error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ General:
 - Fix notifications showing in Opera and Firefox < 5
 - No temptation to judge
 - An embedded chat (http://chat.grompe.org.ru/#drawception)
+- Automatically retry failed requests to reduce annoying error messages
 
 Canvas:
 
@@ -91,6 +92,9 @@ Forum:
 - add simple layers(?)
 
 ## CHANGELOG
+
+0.62.2014.9
+- Automatically retry failed requests to reduce annoying error messages
 
 0.61.2014.9
 - Option to track changes in unfinished games list (merged with your panel position option)


### PR DESCRIPTION
I have added an option (enabled by default) to automatically retry all failed AJAX requests up to 5 times.
Comment requests are not retried to avoid duplicates. Post button is fixed instead.
Errors on _like_ and _skip_ requests which occur because the request actually succeeds are removed and the page is updated to reflect actual changes.
Additionally the mouse cursor now indicates if requests are in progress, so you know when it is safe to leave the page.
