### PR TITLE
Fixing `.panel-details` overflowing when AJAX loader image is shown

### DIFF
--- a/drawception-anbt.user.js
+++ b/drawception-anbt.user.js
@@ -2741,7 +2741,9 @@ function pageEnhancements()
     addScriptSettings();
   }
   GM_addStyle(
-    ".thumbnail > .panel-details {max-height: 30px}" +
+    ".thumbnail > .panel-details {max-height: 30px; overflow: visible; display: flex; flex-direction: row-reverse; justify-content: space-between }" +
+    ".thumbnail > .panel-details > .btn-group.pull-right {float: none !important; flex-grow: 0; flex-shrink: 0 }" +
+    ".thumbnail > .panel-details > .panel-user  flex-grow: 0; flex-shrink: 1 }" +
     ".gpe-wide {display: none}" +
     ".gpe-btn {padding: 5px 8px; height: 28px}" +
     ".gpe-spacer {margin-right: 7px; float:left}" +


### PR DESCRIPTION
See this screenshot: http://imgur.com/V3NAQet

This fix should work on all current major browsers, except Safari (that still requires a prefix). http://caniuse.com/#feat=flexbox
