### PR TITLE
Removing onclick from (re)play button

### DIFF
--- a/drawception-anbt.user.js
+++ b/drawception-anbt.user.js
@@ -1763,12 +1763,7 @@ function betterView()
       checkForRecording(this.src, function()
       {
         var id = scrambleID(panel.attr("id").slice(6));
-        var replayButton = $('<a href="/sandbox/#' + id + '" class="panel-number anbt_replaypanel glyphicon glyphicon-repeat text-muted" title="Replay"></span>');
-        replayButton.click(function(e)
-        {
-          e.preventDefault();
-          location.href = "/forums/post-preview/#newcanvas_sandbox/" + id;
-        });
+        var replayButton = $('<a href="/forums/post-preview/#newcanvas_sandbox/' + id + '" class="panel-number anbt_replaypanel glyphicon glyphicon-repeat text-muted" title="Replay"></span>');
         panel.before(replayButton);
       });
     };


### PR DESCRIPTION
Removing the onclick handler enables middle-clicking to open in a new tab.

I wonder why the script redirects to `/forums/post-preview/` and then redirects to `/sandbox/`. Why not to the sandbox directly?
