### PR TITLE
Fix for Drawception's new Favorite button

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+1.119.2018.02
+- Update Like All and Reverse buttons to work with new Drawception UI
+
 1.118.2018.02
 - New canvas: resolve error in sandbox (window.gameinfo is not set)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## This is a fork of https://github.com/grompe/Drawception-ANBT with the addition of a fix to make the ```Like All``` and ```Reverse``` appear on the latest version of the Drawception website
+## This is a fork of https://github.com/grompe/Drawception-ANBT with the addition of a fix to make the ```Like All``` and ```Reverse``` buttons appear on the latest version of the Drawception website
 
 Drawception ANBT [![Public domain](http://i.creativecommons.org/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)
 ================

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-## This is a fork of https://github.com/grompe/Drawception-ANBT with the addition of a fix to make the ```Like All``` and ```Reverse``` buttons appear on the latest version of the Drawception website
 
 Drawception ANBT [![Public domain](http://i.creativecommons.org/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)
 ================
 
 A userscript to make Drawception.com better: more drawing tools, tablet support, sandbox with palettes and uploading to imgur, like all, quick menu buttons with old browser support, and other enhancements.
 
-[**Direct script link**](https://raw.github.com/bertrandthehealer/Drawception-ANBT/master/drawception-anbt.user.js) (use to install/update manually, or "save as...")
+[**Direct script link**](https://raw.github.com/grompe/Drawception-ANBT/master/drawception-anbt.user.js) (use to install/update manually, or "save as...")
 
 [New canvas with recording and playback, standalone version](http://grompe.org.ru/drawit/)
 
@@ -26,11 +25,11 @@ A userscript to make Drawception.com better: more drawing tools, tablet support,
 - Mobile browsers / other / single use:
   - create a bookmark with the following URL:
 
-    `javascript:void($.ajax({dataType:"script",cache:!0,url:"//rawgit.com/bertrandthehealer/Drawception-ANBT/master/drawception-anbt.user.js"}))`
+    `javascript:void($.ajax({dataType:"script",cache:!0,url:"//rawgit.com/grompe/Drawception-ANBT/master/drawception-anbt.user.js"}))`
     
     and follow it while being on drawception.com site; if that doesn't work, try pasting it in the address bar.
 
-After installing script management add-on, just click on the [**Direct script link**](https://raw.github.com/bertrandthehealer/Drawception-ANBT/master/drawception-anbt.user.js).
+After installing script management add-on, just click on the [**Direct script link**](https://raw.github.com/grompe/Drawception-ANBT/master/drawception-anbt.user.js).
 
 
 ## FEATURES
@@ -88,4 +87,4 @@ Forum:
 
 ## CHANGELOG
 
-See https://raw.github.com/bertrandthehealer/Drawception-ANBT/master/CHANGELOG.txt
+See https://raw.github.com/grompe/Drawception-ANBT/master/CHANGELOG.txt

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
+## This is a fork of https://github.com/grompe/Drawception-ANBT with the addition of a fix to make the ```Like All``` and ```Reverse``` appear on the latest version of the Drawception website
+
 Drawception ANBT [![Public domain](http://i.creativecommons.org/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)
 ================
 
 A userscript to make Drawception.com better: more drawing tools, tablet support, sandbox with palettes and uploading to imgur, like all, quick menu buttons with old browser support, and other enhancements.
 
-[**Direct script link**](https://raw.github.com/grompe/Drawception-ANBT/master/drawception-anbt.user.js) (use to install/update manually, or "save as...")
+[**Direct script link**](https://raw.github.com/bertrandthehealer/Drawception-ANBT/master/drawception-anbt.user.js) (use to install/update manually, or "save as...")
 
 [New canvas with recording and playback, standalone version](http://grompe.org.ru/drawit/)
 
@@ -24,11 +26,11 @@ A userscript to make Drawception.com better: more drawing tools, tablet support,
 - Mobile browsers / other / single use:
   - create a bookmark with the following URL:
 
-    `javascript:void($.ajax({dataType:"script",cache:!0,url:"//rawgit.com/grompe/Drawception-ANBT/master/drawception-anbt.user.js"}))`
+    `javascript:void($.ajax({dataType:"script",cache:!0,url:"//rawgit.com/bertrandthehealer/Drawception-ANBT/master/drawception-anbt.user.js"}))`
     
     and follow it while being on drawception.com site; if that doesn't work, try pasting it in the address bar.
 
-After installing script management add-on, just click on the [**Direct script link**](https://raw.github.com/grompe/Drawception-ANBT/master/drawception-anbt.user.js).
+After installing script management add-on, just click on the [**Direct script link**](https://raw.github.com/bertrandthehealer/Drawception-ANBT/master/drawception-anbt.user.js).
 
 
 ## FEATURES
@@ -86,4 +88,4 @@ Forum:
 
 ## CHANGELOG
 
-See https://raw.github.com/grompe/Drawception-ANBT/master/CHANGELOG.txt
+See https://raw.github.com/bertrandthehealer/Drawception-ANBT/master/CHANGELOG.txt

--- a/drawception-anbt.user.js
+++ b/drawception-anbt.user.js
@@ -2108,7 +2108,7 @@ function betterGame()
     $(".panel-user").find('a[href*="/' + userid + '/"]').parent().parent().find("span.disabled .numlikes").text("?").css("opacity", "0.5");
 
   // Reverse panels button and like all button
-  $("#btn-remove-favorite")
+  $('div[data-v-baf71e0a=""]').first()
     .after(' <a href="#" class="btn btn-default" onclick="return reversePanels();" title="Reverse panels"><span class="glyphicon glyphicon-refresh"></span> Reverse</a>')
     .after(' <a href="#" class="btn btn-default" onclick="return likeAll();" title="Like all panels"><span class="glyphicon glyphicon-thumbs-up"></span> Like all</a>');
 

--- a/drawception-anbt.user.js
+++ b/drawception-anbt.user.js
@@ -2108,7 +2108,7 @@ function betterGame()
     $(".panel-user").find('a[href*="/' + userid + '/"]').parent().parent().find("span.disabled .numlikes").text("?").css("opacity", "0.5");
 
   // Reverse panels button and like all button
-  $('div[data-v-baf71e0a=""]').first()
+  $('div.btn-group.btn-group-lg').first()
     .after(' <a href="#" class="btn btn-default" onclick="return reversePanels();" title="Reverse panels"><span class="glyphicon glyphicon-refresh"></span> Reverse</a>')
     .after(' <a href="#" class="btn btn-default" onclick="return likeAll();" title="Like all panels"><span class="glyphicon glyphicon-thumbs-up"></span> Like all</a>');
 

--- a/drawception-anbt.user.js
+++ b/drawception-anbt.user.js
@@ -2,7 +2,7 @@
 // @name         Drawception ANBT
 // @author       Grom PE
 // @namespace    http://grompe.org.ru/
-// @version      1.118.2018.02
+// @version      1.118.2018.03
 // @description  Enhancement script for Drawception.com - Artists Need Better Tools
 // @downloadURL  https://raw.github.com/grompe/Drawception-ANBT/master/drawception-anbt.user.js
 // @match        http://drawception.com/*
@@ -14,7 +14,7 @@
 
 function wrapped() {
 
-var SCRIPT_VERSION = "1.118.2018.02";
+var SCRIPT_VERSION = "1.118.2018.03";
 var NEWCANVAS_VERSION = 34; // Increase to update the cached canvas
 var SITE_VERSION = "2.7.4"; // Last seen site version
 

--- a/drawception-anbt.user.js
+++ b/drawception-anbt.user.js
@@ -2,7 +2,7 @@
 // @name         Drawception ANBT
 // @author       Grom PE
 // @namespace    http://grompe.org.ru/
-// @version      1.118.2018.03
+// @version      1.119.2018.02
 // @description  Enhancement script for Drawception.com - Artists Need Better Tools
 // @downloadURL  https://raw.github.com/grompe/Drawception-ANBT/master/drawception-anbt.user.js
 // @match        http://drawception.com/*
@@ -14,7 +14,7 @@
 
 function wrapped() {
 
-var SCRIPT_VERSION = "1.118.2018.03";
+var SCRIPT_VERSION = "1.119.2018.02";
 var NEWCANVAS_VERSION = 34; // Increase to update the cached canvas
 var SITE_VERSION = "2.7.4"; // Last seen site version
 


### PR DESCRIPTION
Drawception has a new favorite button, which means that ANBT's Like All and Reverse Panels buttons no longer appear:
![screenshot from 2018-02-27 09-58-21](https://user-images.githubusercontent.com/17074869/36739126-cf05dd4e-1ba4-11e8-9a1c-febf9be4bb20.png)
This is a simple fix to add them back:
![screenshot from 2018-02-27 09-59-18](https://user-images.githubusercontent.com/17074869/36739160-e6b17bb0-1ba4-11e8-8795-bb70d4106ca0.png)